### PR TITLE
fix: Prioritize rstats-on-nix in Cachix pull list for workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
-          name: johngavin
-          extraPullNames: rstats-on-nix
+          name: rstats-on-nix
+          extraPullNames: johngavin
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and Test R Package

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
-          name: johngavin
-          extraPullNames: rstats-on-nix
+          name: rstats-on-nix
+          extraPullNames: johngavin
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and Deploy pkgdown site

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
-          name: johngavin
-          extraPullNames: rstats-on-nix
+          name: rstats-on-nix
+          extraPullNames: johngavin
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build nix environment


### PR DESCRIPTION
Updates all CI workflows to prioritize 'rstats-on-nix' over 'johngavin' when pulling from Cachix caches.