### PR TITLE
fix: Correct Nix shell syntax in GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -27,21 +27,19 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and Test R Package
-        shell: nix-shell --run bash -c "{0}" # Use a persistent Nix shell for all R commands
         run: |
-          echo "Nix environment ready"
-
-          echo "Generating documentation..."
-          Rscript -e 'roxygen2::roxygenise()'
-
-          echo "Running R CMD check..."
-          Rscript -e 'devtools::check(error_on = "warning")'
-
-          echo "Running tests..."
-          Rscript -e 'devtools::test()'
-
-          echo "Building package..."
-          R CMD build .
+          nix-shell --run "
+            set -e
+            echo 'Nix environment ready'
+            echo 'Generating documentation...'
+            Rscript -e 'roxygen2::roxygenise()'
+            echo 'Running R CMD check...'
+            Rscript -e 'devtools::check(error_on = \"warning\")'
+            echo 'Running tests...'
+            Rscript -e 'devtools::test()'
+            echo 'Building package...'
+            R CMD build .
+          "
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -37,10 +37,12 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and Deploy pkgdown site
-        shell: nix-shell --run bash -c "{0}" # Use a persistent Nix shell
         run: |
-          echo "Nix environment ready"
-          Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)'
+          nix-shell --run "
+            set -e
+            echo 'Nix environment ready'
+            Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)'
+          "
 
       - name: Deploy to GitHub pages
         if: github.event_name != 'pull_request'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -30,16 +30,20 @@ jobs:
         run: nix-shell --run "echo 'Nix environment ready'"
 
       - name: Test coverage
-        shell: nix-shell --run bash -c "{0}"
         run: |
-          if (!requireNamespace("covr", quietly = TRUE)) {
-            install.packages("covr")
-          }
-          covr::codecov(
-            quiet = FALSE,
-            clean = FALSE,
-            token = "${{ secrets.CODECOV_TOKEN }}"
-          )
+          nix-shell --run "
+            set -e
+            Rscript -e '
+              if (!requireNamespace(\"covr\", quietly = TRUE)) {
+                install.packages(\"covr\")
+              }
+              covr::codecov(
+                quiet = FALSE,
+                clean = FALSE,
+                token = \"${{ secrets.CODECOV_TOKEN }}\"
+              )
+            '
+          "
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Reverts to 'run: nix-shell --run ...' syntax to avoid argument parsing errors with 'shell:' override.